### PR TITLE
Fixed power pin properties on symbols

### DIFF
--- a/xschem/Stage0_clk_inv.sym
+++ b/xschem/Stage0_clk_inv.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.4 file_version=1.2
+v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {type=subcircuit
@@ -29,11 +29,11 @@ L 4 80 -40 520 -40 {}
 L 4 280 -80 510 -80 {}
 L 4 280 -130 280 -80 {}
 L 4 90 -210 230 -130 {}
-B 5 147.5 -242.5 152.5 -237.5 {name=dvddb sig_type=std_logic dir=in}
+B 5 147.5 -242.5 152.5 -237.5 {name=dvddb dir=in}
 B 5 527.5 -132.5 532.5 -127.5 {name=clka sig_type=std_logic dir=out}
 B 5 67.5 -132.5 72.5 -127.5 {name=clk dir=in}
 B 5 527.5 -82.5 532.5 -77.5 {name=clkb sig_type=std_logic dir=out}
-B 5 147.5 -32.5 152.5 -27.5 {name=dvss sig_type=std_logic dir=out}
+B 5 147.5 -32.5 152.5 -27.5 {name=dvss dir=in}
 A 4 235 -130 11.18033988749895 243.434948822922 360 {}
 A 4 475 -130 11.18033988749895 243.434948822922 360 {}
 T {@symname} 369 -216 0 0 0.3 0.3 {}

--- a/xschem/Stage0_ena_inv.sym
+++ b/xschem/Stage0_ena_inv.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.4 file_version=1.2
+v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {type=subcircuit
@@ -23,10 +23,10 @@ L 4 190 -220 190 -50 {}
 L 4 190 -50 410 -50 {}
 L 4 410 -220 410 -50 {}
 L 4 190 -220 410 -220 {}
-B 5 287.5 -232.5 292.5 -227.5 {name=dvdd sig_type=std_logic dir=in}
+B 5 287.5 -232.5 292.5 -227.5 {name=dvdd dir=in}
 B 5 177.5 -132.5 182.5 -127.5 {name=ena dir=in}
 B 5 417.5 -132.5 422.5 -127.5 {name=enab sig_type=std_logic dir=out}
-B 5 287.5 -42.5 292.5 -37.5 {name=dvss sig_type=std_logic dir=out}
+B 5 287.5 -42.5 292.5 -37.5 {name=dvss dir=in}
 A 4 365 -130 11.18033988749895 243.434948822922 360 {}
 T {@symname} 299 -206 0 0 0.3 0.3 {}
 T {@name} 365 -242 0 0 0.2 0.2 {}

--- a/xschem/Stage2_latch.sym
+++ b/xschem/Stage2_latch.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.4 file_version=1.2
+v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {type=subcircuit
@@ -40,7 +40,7 @@ B 5 307.5 -102.5 312.5 -97.5 {name=clkb sig_type=std_logic dir=in}
 B 5 447.5 -192.5 452.5 -187.5 {name=vout dir=out}
 B 5 217.5 -172.5 222.5 -167.5 {name=oneg sig_type=std_logic dir=in}
 B 5 217.5 -212.5 222.5 -207.5 {name=opos sig_type=std_logic dir=in}
-B 5 347.5 -102.5 352.5 -97.5 {name=dvss dir=out}
+B 5 347.5 -102.5 352.5 -97.5 {name=dvss dir=in}
 T {@symname} 268 -206 0 0 0.3 0.3 {}
 T {@name} 395 -302 0 0 0.2 0.2 {}
 T {dvdd} 355 -274 0 0 0.2 0.2 {}


### PR DESCRIPTION
Probably not a fatal error anywhere, but power pins defined as standard logic output on symbols resulted in warning messages when netlisting. This PR resolves the issue.

`Warning: shorted output node: dvss`