### PR TITLE
Changes to pin instances (out->in) to match previous symbol changes

### DIFF
--- a/xschem/Stage0_clk_inv.sch
+++ b/xschem/Stage0_clk_inv.sch
@@ -1,4 +1,4 @@
-v {xschem version=3.4.4 file_version=1.2
+v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {}
@@ -39,7 +39,7 @@ N 310 -230 370 -230 {
 lab=clkb}
 N 410 -230 490 -230 {
 lab=clka}
-C {devices/opin.sym} 250 -80 0 0 {name=p11 sig_type=std_logic lab=dvss}
+C {devices/ipin.sym} 250 -80 0 0 {name=p11 sig_type=std_logic lab=dvss}
 C {devices/ipin.sym} 250 -360 0 0 {name=p12 sig_type=std_logic lab=dvddb}
 C {devices/opin.sym} 490 -230 0 0 {name=p14 sig_type=std_logic lab=clka
 }

--- a/xschem/Stage0_ena_inv.sch
+++ b/xschem/Stage0_ena_inv.sch
@@ -1,4 +1,4 @@
-v {xschem version=3.4.4 file_version=1.2
+v {xschem version=3.4.5 file_version=1.2
 }
 G {}
 K {}
@@ -25,7 +25,7 @@ N 240 -110 240 -50 {
 lab=dvss}
 C {devices/ipin.sym} 160 -200 0 0 {name=p27 lab=ena}
 C {devices/ipin.sym} 240 -330 0 0 {name=p28 sig_type=std_logic lab=dvdd}
-C {devices/opin.sym} 240 -50 0 0 {name=p33 sig_type=std_logic lab=dvss}
+C {devices/ipin.sym} 240 -50 0 0 {name=p33 sig_type=std_logic lab=dvss}
 C {devices/opin.sym} 290 -200 0 0 {name=p37 sig_type=std_logic lab=enab}
 C {sky130_fd_pr/pfet_01v8.sym} 220 -250 0 0 {name=M25
 L=0.5

--- a/xschem/Stage2_latch.sch
+++ b/xschem/Stage2_latch.sch
@@ -103,7 +103,8 @@ N 80 -400 120 -400 {
 lab=vout}
 N 510 -640 510 -610 {
 lab=dvdd}
-N 120 -490 120 -460 {}
+N 120 -490 120 -460 {
+lab=dvddb}
 C {devices/ipin.sym} 220 -460 0 0 {name=p15 sig_type=std_logic lab=clkb
 }
 C {devices/lab_pin.sym} 840 -460 2 0 {name=p16 sig_type=std_logic lab=clkb
@@ -111,7 +112,7 @@ C {devices/lab_pin.sym} 840 -460 2 0 {name=p16 sig_type=std_logic lab=clkb
 C {devices/lab_pin.sym} 410 -140 0 0 {name=p17 sig_type=std_logic lab=clkb
 }
 C {devices/opin.sym} 80 -400 2 0 {name=p18 lab=vout}
-C {devices/opin.sym} 520 -60 0 0 {name=p19 lab=dvss}
+C {devices/ipin.sym} 520 -60 0 0 {name=p19 lab=dvss}
 C {devices/lab_pin.sym} 680 -250 2 0 {name=p20 sig_type=std_logic lab=dvss}
 C {devices/lab_pin.sym} 360 -250 0 0 {name=p21 sig_type=std_logic lab=dvss}
 C {devices/lab_pin.sym} 400 -310 2 0 {name=p22 sig_type=std_logic lab=dvss}


### PR DESCRIPTION
@RTimothyEdwards the previous change to remove warnings causes errors higher in the hierarchy. This corrects everything.

The addition of the net name `dvddb` in line 107 of `xschem/Stage2_latch.sch` is at a connecte pmos source terminal. It may have been generated to to a xschem version increase. I don't think it affects anything, though.